### PR TITLE
Bound flat-merge per-output cursor work in page access reservation

### DIFF
--- a/crates/icydb-core/src/db/executor/stream/key/composite.rs
+++ b/crates/icydb-core/src/db/executor/stream/key/composite.rs
@@ -524,7 +524,17 @@ where
         // The first output initializes one head per child and refreshes each
         // child whose duplicate head is consumed. Later outputs do at most the
         // same amount of work, so twice the child-pull sum is a finite bound.
-        child_pull_bound.checked_mul(2)
+        //
+        // `next_key` additionally charges one cursor step for the heap pop and
+        // one for every duplicate head it consumes, whether or not any child
+        // needs a fresh pull. Once every child already holds its head the
+        // child-pull sum is zero, so that per-output merge work has to be
+        // bounded on its own; otherwise the enclosing scalar page unit reserves
+        // fewer cursor steps than the merge spends and the observed delta trips
+        // the executor invariant in `commit_observed`.
+        child_pull_bound
+            .checked_mul(2)?
+            .checked_add(self.children.len())
     }
 }
 

--- a/crates/icydb-core/src/db/executor/stream/key/tests.rs
+++ b/crates/icydb-core/src/db/executor/stream/key/tests.rs
@@ -715,7 +715,25 @@ fn composite_page_pull_bounds_cover_initialization_and_duplicate_refresh() {
             comparator,
         )
         .expect("flat merge topology should be admitted");
-    assert_eq!(flat.page_access_entry_bound(), Some(18));
+    // Twice the child-pull sum (9) plus one per child for the heap pop and
+    // duplicate-head consumption that `next_key` charges on every output.
+    assert_eq!(flat.page_access_entry_bound(), Some(21));
+
+    // Regression: once every child already holds its head the child-pull sum is
+    // zero, but `next_key` still charges cursor steps for the heap pop and each
+    // duplicate it consumes. A zero bound under-reserves the enclosing scalar
+    // page unit, so the observed delta trips the executor invariant.
+    let settled =
+        crate::db::executor::stream::key::FlatMergeOrderedKeyStream::try_new_with_comparator(
+            vec![
+                StaticOrderedKeyStream::new(vec![data_key(1)]).with_page_access_entry_bound(0),
+                StaticOrderedKeyStream::new(vec![data_key(2)]).with_page_access_entry_bound(0),
+                StaticOrderedKeyStream::new(vec![data_key(3)]).with_page_access_entry_bound(0),
+            ],
+            comparator,
+        )
+        .expect("flat merge topology should be admitted");
+    assert_eq!(settled.page_access_entry_bound(), Some(3));
 
     let intersection = IntersectOrderedKeyStream::new_with_comparator(
         StaticOrderedKeyStream::new(vec![data_key(1)]).with_page_access_entry_bound(1),


### PR DESCRIPTION
## Problem

An ordinary multi-value read fails with `E20` `RUNTIME_INVARIANT_VIOLATION`. Minimal shape — an `IN`-list filter ordered by a different field:

```rust
db!().query::<GeneratorPart>()
    .filter(FilterExpr::in_list("layer_id", layer_ids))  // 3 values -> flat merge
    .order_asc("id")
    .partial_window(10_000)
    .trusted_read_unchecked()
    .execute_rows()
```

It is not cumulative (fails on the first call), not paging-related, and not budget pressure — the observed overrun is `reserved=1 observed=2` against a limit of `100000`.

## Cause

`FlatMergeOrderedKeyStream::next_key` charges one `CursorSteps` unit for the heap pop, and one more for every duplicate head it consumes, **whether or not any child needs a fresh pull**.

`page_access_entry_bound` reported only `child_pull_bound * 2`. Once every child already holds its head, `next_pull_entry_bound()` returns `0` for each child, so the bound collapses to `0`.

The enclosing scalar page unit sizes its reservation from that bound (`scalar_candidate_inspection_reservation`: `cursor_steps = access_entries * 3 + 1`), reserving a single cursor step while the merge spends two. `PageWorkTracker::commit_observed` then rejects the overrun as an executor invariant violation.

## Fix

Add one entry per child so the merge's own per-output work stays bounded when the child-pull sum is zero. Reservations are conservative and released on completion, so over-reserving is safe.

## Verification

- `cargo test -p icydb-core --lib` — 1304 passed, 0 failed
- Full workspace: 2430 passed / 118 failed, **identical to the `v0.223.0` baseline** measured by stashing the change; no regressions introduced
- Downstream (Toko, `in_list` reads through the typed adapter): 633 passing / 3 failing → 634 / 2

`composite_page_pull_bounds_cover_initialization_and_duplicate_refresh` pinned the old value (`Some(18)` → `Some(21)`). That test asserts the bound *covers* initialization and duplicate refresh; the previous value did not cover the heap-pop charges. A regression case for the zero-child-pull path is added alongside it.